### PR TITLE
Merge on upsert

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -387,7 +387,7 @@ ___
 
 ▸ **cortexCredentialsProviderFactory**<**T**>(`ops`: [CredentialProviderOptions](interfaces/credentialprovideroptions.md) & object, `storage`: [SecretsStorage](interfaces/secretsstorage.md)‹T›): *[CortexCredentialProvider](classes/cortexcredentialprovider.md)‹T›*
 
-*Defined in [src/hub/credentials_provider.ts:596](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L596)*
+*Defined in [src/hub/credentials_provider.ts:597](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L597)*
 
 Buils a CortexCredentialsObject from provided options and storage object
 

--- a/doc/classes/cortexcredentialprovider.md
+++ b/doc/classes/cortexcredentialprovider.md
@@ -88,7 +88,7 @@ Name | Type | Description |
 
 ▸ **addWithCode**(`datalakeId`: string, `entryPoint`: string, `oa2code`: object, `metadata?`: T): *Promise‹[Credentials](../interfaces/credentials.md)›*
 
-*Defined in [src/hub/credentials_provider.ts:404](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L404)*
+*Defined in [src/hub/credentials_provider.ts:405](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L405)*
 
 Issues a new credentials object for a datalake you have static access to
 its initial code.
@@ -127,7 +127,7 @@ ___
 
 ▸ **addWithRefreshToken**(`datalakeId`: string, `entryPoint`: string, `refreshToken`: string, `prefetch?`: undefined | object, `metadata?`: T): *Promise‹[Credentials](../interfaces/credentials.md)›*
 
-*Defined in [src/hub/credentials_provider.ts:362](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L362)*
+*Defined in [src/hub/credentials_provider.ts:363](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L363)*
 
 Issues a new credentials object for a datalake you have static access to its `refreshToken`.
 
@@ -151,7 +151,7 @@ ___
 
 ▸ **deleteDatalake**(`datalakeId`: string): *Promise‹void›*
 
-*Defined in [src/hub/credentials_provider.ts:497](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L497)*
+*Defined in [src/hub/credentials_provider.ts:498](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L498)*
 
 Completely removes a datalake from the store (it revokes the refresh
 token if already authorized)
@@ -172,7 +172,7 @@ ___
 
 *Implementation of [SecretsStorage](../interfaces/secretsstorage.md)*
 
-*Defined in [src/hub/credentials_provider.ts:570](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L570)*
+*Defined in [src/hub/credentials_provider.ts:571](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L571)*
 
 Implementation dependant. Must delete an item from the store
 
@@ -190,7 +190,7 @@ ___
 
 ▸ **getAccessToken**(`datalakeId`: string, `force`: boolean): *Promise‹string | undefined›*
 
-*Defined in [src/hub/credentials_provider.ts:512](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L512)*
+*Defined in [src/hub/credentials_provider.ts:513](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L513)*
 
 Main method used by a bound Credentials object. Returns the current `access_token` and its
 expiration time. It auto-refreshes the `access_token` if needed based on the `accTokenGuardTime`
@@ -227,7 +227,7 @@ ___
 
 ▸ **getCredentialsObject**(`datalakeId`: string): *Promise‹[Credentials](../interfaces/credentials.md)›*
 
-*Defined in [src/hub/credentials_provider.ts:437](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L437)*
+*Defined in [src/hub/credentials_provider.ts:438](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L438)*
 
 Retrieves the Credentials object for a given datalake
 
@@ -249,7 +249,7 @@ ___
 
 *Implementation of [SecretsStorage](../interfaces/secretsstorage.md)*
 
-*Defined in [src/hub/credentials_provider.ts:577](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L577)*
+*Defined in [src/hub/credentials_provider.ts:578](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L578)*
 
 Implementation dependant. Must return the store item
 
@@ -269,7 +269,7 @@ ___
 
 ▸ **loadDb**(`store`: object): *Promise‹void›*
 
-*Defined in [src/hub/credentials_provider.ts:585](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L585)*
+*Defined in [src/hub/credentials_provider.ts:586](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L586)*
 
 Implementation dependant. A way to trigger the external DB initial load must be provided.
 The subclass implementation should compare the protected object `store`
@@ -289,7 +289,7 @@ ___
 
 ▸ **revokeDatalake**(`datalakeId`: string): *Promise‹void›*
 
-*Defined in [src/hub/credentials_provider.ts:457](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L457)*
+*Defined in [src/hub/credentials_provider.ts:458](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L458)*
 
 Revokes a previous authorized datalake (revokes its OAUTH2 `refresh_token`)
 
@@ -348,7 +348,7 @@ ___
 
 *Implementation of [SecretsStorage](../interfaces/secretsstorage.md)*
 
-*Defined in [src/hub/credentials_provider.ts:564](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L564)*
+*Defined in [src/hub/credentials_provider.ts:565](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L565)*
 
 Implementation dependant. Must create or update the corresponfing item in
 the store

--- a/doc/classes/credentialsdebugger.md
+++ b/doc/classes/credentialsdebugger.md
@@ -106,7 +106,7 @@ ___
 
 *Inherited from [CortexCredentialProvider](cortexcredentialprovider.md).[addWithCode](cortexcredentialprovider.md#addwithcode)*
 
-*Defined in [src/hub/credentials_provider.ts:404](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L404)*
+*Defined in [src/hub/credentials_provider.ts:405](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L405)*
 
 Issues a new credentials object for a datalake you have static access to
 its initial code.
@@ -147,7 +147,7 @@ ___
 
 *Inherited from [CortexCredentialProvider](cortexcredentialprovider.md).[addWithRefreshToken](cortexcredentialprovider.md#addwithrefreshtoken)*
 
-*Defined in [src/hub/credentials_provider.ts:362](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L362)*
+*Defined in [src/hub/credentials_provider.ts:363](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L363)*
 
 Issues a new credentials object for a datalake you have static access to its `refreshToken`.
 
@@ -173,7 +173,7 @@ ___
 
 *Inherited from [CortexCredentialProvider](cortexcredentialprovider.md).[deleteDatalake](cortexcredentialprovider.md#deletedatalake)*
 
-*Defined in [src/hub/credentials_provider.ts:497](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L497)*
+*Defined in [src/hub/credentials_provider.ts:498](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L498)*
 
 Completely removes a datalake from the store (it revokes the refresh
 token if already authorized)
@@ -214,7 +214,7 @@ ___
 
 *Inherited from [CortexCredentialProvider](cortexcredentialprovider.md).[getAccessToken](cortexcredentialprovider.md#getaccesstoken)*
 
-*Defined in [src/hub/credentials_provider.ts:512](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L512)*
+*Defined in [src/hub/credentials_provider.ts:513](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L513)*
 
 Main method used by a bound Credentials object. Returns the current `access_token` and its
 expiration time. It auto-refreshes the `access_token` if needed based on the `accTokenGuardTime`
@@ -255,7 +255,7 @@ ___
 
 *Inherited from [CortexCredentialProvider](cortexcredentialprovider.md).[getCredentialsObject](cortexcredentialprovider.md#getcredentialsobject)*
 
-*Defined in [src/hub/credentials_provider.ts:437](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L437)*
+*Defined in [src/hub/credentials_provider.ts:438](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L438)*
 
 Retrieves the Credentials object for a given datalake
 
@@ -309,7 +309,7 @@ ___
 
 *Inherited from [CortexCredentialProvider](cortexcredentialprovider.md).[revokeDatalake](cortexcredentialprovider.md#revokedatalake)*
 
-*Defined in [src/hub/credentials_provider.ts:457](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L457)*
+*Defined in [src/hub/credentials_provider.ts:458](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L458)*
 
 Revokes a previous authorized datalake (revokes its OAUTH2 `refresh_token`)
 

--- a/doc/classes/fscredprovider.md
+++ b/doc/classes/fscredprovider.md
@@ -89,7 +89,7 @@ Name | Type | Description |
 
 *Inherited from [CortexCredentialProvider](cortexcredentialprovider.md).[addWithCode](cortexcredentialprovider.md#addwithcode)*
 
-*Defined in [src/hub/credentials_provider.ts:404](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L404)*
+*Defined in [src/hub/credentials_provider.ts:405](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L405)*
 
 Issues a new credentials object for a datalake you have static access to
 its initial code.
@@ -130,7 +130,7 @@ ___
 
 *Inherited from [CortexCredentialProvider](cortexcredentialprovider.md).[addWithRefreshToken](cortexcredentialprovider.md#addwithrefreshtoken)*
 
-*Defined in [src/hub/credentials_provider.ts:362](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L362)*
+*Defined in [src/hub/credentials_provider.ts:363](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L363)*
 
 Issues a new credentials object for a datalake you have static access to its `refreshToken`.
 
@@ -156,7 +156,7 @@ ___
 
 *Inherited from [CortexCredentialProvider](cortexcredentialprovider.md).[deleteDatalake](cortexcredentialprovider.md#deletedatalake)*
 
-*Defined in [src/hub/credentials_provider.ts:497](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L497)*
+*Defined in [src/hub/credentials_provider.ts:498](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L498)*
 
 Completely removes a datalake from the store (it revokes the refresh
 token if already authorized)
@@ -197,7 +197,7 @@ ___
 
 *Inherited from [CortexCredentialProvider](cortexcredentialprovider.md).[getAccessToken](cortexcredentialprovider.md#getaccesstoken)*
 
-*Defined in [src/hub/credentials_provider.ts:512](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L512)*
+*Defined in [src/hub/credentials_provider.ts:513](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L513)*
 
 Main method used by a bound Credentials object. Returns the current `access_token` and its
 expiration time. It auto-refreshes the `access_token` if needed based on the `accTokenGuardTime`
@@ -238,7 +238,7 @@ ___
 
 *Inherited from [CortexCredentialProvider](cortexcredentialprovider.md).[getCredentialsObject](cortexcredentialprovider.md#getcredentialsobject)*
 
-*Defined in [src/hub/credentials_provider.ts:437](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L437)*
+*Defined in [src/hub/credentials_provider.ts:438](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L438)*
 
 Retrieves the Credentials object for a given datalake
 
@@ -294,7 +294,7 @@ ___
 
 *Inherited from [CortexCredentialProvider](cortexcredentialprovider.md).[revokeDatalake](cortexcredentialprovider.md#revokedatalake)*
 
-*Defined in [src/hub/credentials_provider.ts:457](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L457)*
+*Defined in [src/hub/credentials_provider.ts:458](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L458)*
 
 Revokes a previous authorized datalake (revokes its OAUTH2 `refresh_token`)
 

--- a/doc/classes/simplecredentialsprovider.md
+++ b/doc/classes/simplecredentialsprovider.md
@@ -88,7 +88,7 @@ Name | Type | Description |
 
 *Inherited from [CortexCredentialProvider](cortexcredentialprovider.md).[addWithCode](cortexcredentialprovider.md#addwithcode)*
 
-*Defined in [src/hub/credentials_provider.ts:404](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L404)*
+*Defined in [src/hub/credentials_provider.ts:405](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L405)*
 
 Issues a new credentials object for a datalake you have static access to
 its initial code.
@@ -129,7 +129,7 @@ ___
 
 *Inherited from [CortexCredentialProvider](cortexcredentialprovider.md).[addWithRefreshToken](cortexcredentialprovider.md#addwithrefreshtoken)*
 
-*Defined in [src/hub/credentials_provider.ts:362](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L362)*
+*Defined in [src/hub/credentials_provider.ts:363](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L363)*
 
 Issues a new credentials object for a datalake you have static access to its `refreshToken`.
 
@@ -155,7 +155,7 @@ ___
 
 *Inherited from [CortexCredentialProvider](cortexcredentialprovider.md).[deleteDatalake](cortexcredentialprovider.md#deletedatalake)*
 
-*Defined in [src/hub/credentials_provider.ts:497](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L497)*
+*Defined in [src/hub/credentials_provider.ts:498](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L498)*
 
 Completely removes a datalake from the store (it revokes the refresh
 token if already authorized)
@@ -196,7 +196,7 @@ ___
 
 *Inherited from [CortexCredentialProvider](cortexcredentialprovider.md).[getAccessToken](cortexcredentialprovider.md#getaccesstoken)*
 
-*Defined in [src/hub/credentials_provider.ts:512](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L512)*
+*Defined in [src/hub/credentials_provider.ts:513](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L513)*
 
 Main method used by a bound Credentials object. Returns the current `access_token` and its
 expiration time. It auto-refreshes the `access_token` if needed based on the `accTokenGuardTime`
@@ -237,7 +237,7 @@ ___
 
 *Inherited from [CortexCredentialProvider](cortexcredentialprovider.md).[getCredentialsObject](cortexcredentialprovider.md#getcredentialsobject)*
 
-*Defined in [src/hub/credentials_provider.ts:437](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L437)*
+*Defined in [src/hub/credentials_provider.ts:438](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L438)*
 
 Retrieves the Credentials object for a given datalake
 
@@ -291,7 +291,7 @@ ___
 
 *Inherited from [CortexCredentialProvider](cortexcredentialprovider.md).[revokeDatalake](cortexcredentialprovider.md#revokedatalake)*
 
-*Defined in [src/hub/credentials_provider.ts:457](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L457)*
+*Defined in [src/hub/credentials_provider.ts:458](https://github.com/xhoms/pan-cortex-hub-nodejs/blob/master/src/hub/credentials_provider.ts#L458)*
 
 Revokes a previous authorized datalake (revokes its OAUTH2 `refresh_token`)
 

--- a/lib/hub/credentials_provider.js
+++ b/lib/hub/credentials_provider.js
@@ -88,8 +88,9 @@ class CortexCredentialProvider {
         if (dlid) {
             await this.lazyInitStoreItem(dlid);
             if (value) {
-                this.store[dlid] = value;
-                await this.upsertStoreItem(dlid, value);
+                const mergedValue = { ...this.store[dlid], ...value };
+                this.store[dlid] = mergedValue;
+                await this.upsertStoreItem(dlid, mergedValue);
             }
             return this.store[dlid];
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paloaltonetworks/pan-cortex-hub",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Palo Alto Networks Cortex hub client library",
   "homepage": "https://github.com/PaloAltoNetworks/pan-cortex-hub-nodejs#readme",
   "repository": {

--- a/src/hub/credentials_provider.ts
+++ b/src/hub/credentials_provider.ts
@@ -250,8 +250,9 @@ export abstract class CortexCredentialProvider<T> implements SecretsStorage<T> {
         if (dlid) {
             await this.lazyInitStoreItem(dlid)
             if (value) {
-                this.store[dlid] = value
-                await this.upsertStoreItem(dlid, value)
+                const mergedValue = { ...this.store[dlid], ...value }
+                this.store[dlid] = mergedValue
+                await this.upsertStoreItem(dlid, mergedValue)
             }
             return this.store[dlid]
         }


### PR DESCRIPTION
## Description

Under some circumstances a HubHelper might want to just remove the secrets (not the whole record) from a credentials item. This change effectively merges the new record with the old one (instead of blind replacement)

## Motivation and Context

Cover a corner case

## How Has This Been Tested?

Completed the corner case cycle and verified it performs as expected

## Screenshots (if appropriate)

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
